### PR TITLE
Update build targets for QuantaMesh T1048-LB9

### DIFF
--- a/build-config/scripts/onie-build-targets.json
+++ b/build-config/scripts/onie-build-targets.json
@@ -234,7 +234,7 @@
     { "Vendor": "quanta", "Platform": "quanta_dnv",              "BuildEnv": "Debian9",  "Release": "2020.05br", "Architecture": "amd64",   "Notes": "No notes." },
     { "Vendor": "quanta", "Platform": "quanta_come",             "BuildEnv": "Debian9",  "Release": "2020.08br", "Architecture": "amd64",   "Notes": "No notes." },
     { "Vendor": "quanta", "Platform": "quanta_lb8d",             "BuildEnv": "Debian9",  "Release": "None",      "Architecture": "PowerPC", "Notes": "Image size exceeds maximum." },
-    { "Vendor": "quanta", "Platform": "quanta_lb9",              "BuildEnv": "Debian9",  "Release": "2020.05br", "Architecture": "PowerPC", "Notes": "No notes." },
+    { "Vendor": "quanta", "Platform": "quanta_lb9",              "BuildEnv": "Debian9",  "Release": "2021.08br", "Architecture": "PowerPC", "Notes": "No notes for 2021.08br. Does not build on 2022.02br." },
     { "Vendor": "quanta", "Platform": "quanta_ly2",              "BuildEnv": "Debian9",  "Release": "2020.05br", "Architecture": "PowerPC", "Notes": "No notes." },
     { "Vendor": "quanta", "Platform": "quanta_ly2r",             "BuildEnv": "Debian9",  "Release": "2020.05br", "Architecture": "PowerPC", "Notes": "No notes." },
     { "Vendor": "quanta", "Platform": "quanta_ly3",              "BuildEnv": "Debian9",  "Release": "None",      "Architecture": "PowerPC", "Notes": "Image size exceeds maximum." },


### PR DESCRIPTION
`make MACHINEROOT=../machine/quanta MACHINE=quanta_lb9 all demo` succeeds with Debian 9 tools on branch 2021.08br but fails with Debian 10 tools on branch 2022.02br